### PR TITLE
ci: add Supabase keepalive workflow

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,27 @@
+# Prevents Supabase free-tier project from pausing due to inactivity
+# Supabase pauses projects after 7 days without activity
+name: Supabase Keepalive
+
+on:
+  schedule:
+    # Run every 5 days at midnight UTC (before 7-day pause threshold)
+    - cron: "0 0 */5 * *"
+  workflow_dispatch: # Allow manual trigger for testing
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase Database
+        run: |
+          response=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${{ secrets.SUPABASE_URL }}/rest/v1/Song?select=id&limit=1" \
+            -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}")
+
+          if [ "$response" -eq 200 ]; then
+            echo "✓ Supabase ping successful (HTTP $response)"
+          else
+            echo "✗ Supabase ping failed (HTTP $response)"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to ping Supabase every 5 days
- Prevents free-tier project from pausing after 7 days of inactivity

## Setup Required
After merging, add these secrets to the repo:
- `SUPABASE_URL` - Supabase project URL
- `SUPABASE_ANON_KEY` - Supabase anon/public key

## Test plan
- [ ] Add secrets to GitHub repo
- [ ] Manually trigger workflow via Actions tab
- [ ] Verify successful ping (HTTP 200)