### PR TITLE
feat(keepalive): upsert keep_alive table instead of read ping

### DIFF
--- a/.github/workflows/supabase-keepalive-dev.yml
+++ b/.github/workflows/supabase-keepalive-dev.yml
@@ -12,16 +12,20 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Ping Supabase Database
+      - name: Write to Supabase keep_alive table
         run: |
           response=$(curl -s -o /dev/null -w "%{http_code}" \
-            "${{ secrets.DEV_SUPABASE_URL }}/rest/v1/songs?select=id&limit=1" \
+            "${{ secrets.DEV_SUPABASE_URL }}/rest/v1/keep_alive" \
+            -X POST \
             -H "apikey: ${{ secrets.DEV_SUPABASE_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.DEV_SUPABASE_ANON_KEY }}")
+            -H "Authorization: Bearer ${{ secrets.DEV_SUPABASE_ANON_KEY }}" \
+            -H "Content-Type: application/json" \
+            -H "Prefer: resolution=merge-duplicates" \
+            -d '{"id":"singleton","pinged_at":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}')
 
-          if [ "$response" -eq 200 ]; then
-            echo "✓ Dev Supabase ping successful (HTTP $response)"
+          if [ "$response" -eq 200 ] || [ "$response" -eq 201 ]; then
+            echo "✓ Dev Supabase keepalive write successful (HTTP $response)"
           else
-            echo "✗ Dev Supabase ping failed (HTTP $response)"
+            echo "✗ Dev Supabase keepalive write failed (HTTP $response)"
             exit 1
           fi

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -12,16 +12,20 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Ping Supabase Database
+      - name: Write to Supabase keep_alive table
         run: |
           response=$(curl -s -o /dev/null -w "%{http_code}" \
-            "${{ secrets.SUPABASE_URL }}/rest/v1/songs?select=id&limit=1" \
+            "${{ secrets.SUPABASE_URL }}/rest/v1/keep_alive" \
+            -X POST \
             -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}")
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}" \
+            -H "Content-Type: application/json" \
+            -H "Prefer: resolution=merge-duplicates" \
+            -d '{"id":"singleton","pinged_at":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}')
 
-          if [ "$response" -eq 200 ]; then
-            echo "✓ Supabase ping successful (HTTP $response)"
+          if [ "$response" -eq 200 ] || [ "$response" -eq 201 ]; then
+            echo "✓ Supabase keepalive write successful (HTTP $response)"
           else
-            echo "✗ Supabase ping failed (HTTP $response)"
+            echo "✗ Supabase keepalive write failed (HTTP $response)"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ out/
 plans/
 repomix-output.xml
 
+# ai devkit tooling
+.agents/
+.codex/
+.ai-devkit.json
+docs/ai/
+
 
 # debug
 npm-debug.log*

--- a/apps/api/prisma/migrations/20260521000000_add_keep_alive_table/migration.sql
+++ b/apps/api/prisma/migrations/20260521000000_add_keep_alive_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "keep_alive" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "pinged_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "keep_alive_pkey" PRIMARY KEY ("id")
+);
+
+-- Enable RLS and allow anon upsert
+ALTER TABLE "keep_alive" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow anon upsert" ON "keep_alive"
+    FOR ALL USING (true) WITH CHECK (true);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,6 +31,13 @@ model Song {
   @@map("songs")
 }
 
+model KeepAlive {
+  id       String   @id @default("singleton")
+  pingedAt DateTime @default(now()) @map("pinged_at")
+
+  @@map("keep_alive")
+}
+
 model Image {
   id          String   @id @default(uuid())
   title       String   @db.VarChar(255)

--- a/apps/web/components/LoveDays/ProfileSection.tsx
+++ b/apps/web/components/LoveDays/ProfileSection.tsx
@@ -46,7 +46,7 @@ const ProfileSection = () => {
           <div className="w-full h-full rounded-full bg-card overflow-hidden">
             <Image
               src={MiuLem}
-              alt="Mỉu Lem"
+              alt="Mỉu Nem"
               className="w-full h-full object-cover"
               width={144}
               height={144}
@@ -54,7 +54,7 @@ const ProfileSection = () => {
           </div>
         </div>
         <h3 className="mt-2 font-display text-lg md:text-xl lg:text-2xl font-semibold text-foreground">
-          Mỉu Lem
+          Mỉu Nem
         </h3>
         <p className="text-xs md:text-sm text-muted-foreground font-body">Forever mine</p>
       </div>

--- a/scripts/worker.js
+++ b/scripts/worker.js
@@ -1,0 +1,73 @@
+export default {
+  async fetch(request, env) {
+    if (request.method === "GET") {
+      return await pingSupabase(env);
+    }
+    return new Response("Method not allowed", { status: 405 });
+  },
+
+  async scheduled(event, env) {
+    return await pingSupabase(env);
+  },
+};
+
+async function pingSupabase(env) {
+  try {
+    if (!env.SUPABASE_URL || !env.SUPABASE_ANON_KEY) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Missing environment variables",
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const url = `${env.SUPABASE_URL}/rest/v1/keep_alive`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        apikey: env.SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${env.SUPABASE_ANON_KEY}`,
+        "Content-Type": "application/json",
+        Prefer: "resolution=merge-duplicates",
+      },
+      body: JSON.stringify({
+        id: "singleton",
+        pinged_at: new Date().toISOString(),
+      }),
+    });
+
+    const responseText = await response.text();
+
+    if (response.ok) {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: "Supabase keep-alive write successful",
+          status: response.status,
+          supabaseResponse: responseText,
+          timestamp: new Date().toISOString(),
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    throw new Error(`Upsert failed (${response.status}): ${responseText}`);
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error.message,
+        timestamp: new Date().toISOString(),
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Switches both Supabase keepalive workflows from a read query against the `songs` table to an **upsert against a dedicated `keep_alive` table**, so the scheduled ping exercises a write path (more reliably preventing the free-tier project from pausing).

## Changes

- **CI workflows** (`supabase-keepalive.yml`, `supabase-keepalive-dev.yml`): `POST` to `/rest/v1/keep_alive` with `Prefer: resolution=merge-duplicates`, upserting a `singleton` row with the current timestamp. Accepts both `200` and `201` as success.
- **Prisma** (`schema.prisma` + new migration `20260521000000_add_keep_alive_table`): adds the `KeepAlive` model / `keep_alive` table, enables RLS, and adds a policy allowing anon upsert.
- **`scripts/worker.js`**: Cloudflare Worker performing the same upsert on a schedule (and via GET), as an alternative/redundant keepalive.
- **`.gitignore`**: ignore local AI DevKit tooling (`.agents/`, `.codex/`, `.ai-devkit.json`, `docs/ai/`).

## Notes

The `keep_alive` table must exist in the target Supabase project before the workflows succeed — apply the migration (or create the table + RLS policy manually) on prod and dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)